### PR TITLE
Roel forward accept encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ STRIP_PATH                | Strip path prefix.                                | 
 CONTENT_ENCODING          | Compress response data if the request allows.     |          | false
 HEALTHCHECK_PATH          | If it's specified, the path always returns 200 OK |          | -
 GET_ALL_PAGES_IN_DIR      | If true will make several calls to get all pages of destination directory |          | false
+MAX_IDLE_CONNECTIONS      | Allowed number of idle connections to the S3 storage |       | 150
+IDLE_CONNECTION_TIMEOUT   | Allowed timeout to the S3 storage.                |          | 10
+DISABLE_COMPRESSION       | If true will pass encoded content through as-is.  |          | true
 
 ### 2. Run the application
 

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ var (
 	client  *http.Client
 )
 
-func ConfigureClient() {
+func configureClient() {
 	transport := &http.Transport{
 		MaxIdleConns:       c.maxIdleConns,
 		IdleConnTimeout:    c.idleConnTimeout,
@@ -79,7 +79,7 @@ func ConfigureClient() {
 
 func main() {
 	c = configFromEnvironmentVariables()
-	ConfigureClient()
+	configureClient()
 
 	http.Handle("/", wrapper(awss3))
 


### PR DESCRIPTION
*Problem:*
AWS S3 can serve files with a `Content-Encoding` response header when this attribute is set in S3 with a metadata attribute. The aws-s3-proxy decoded the files with a `Content-Encoding` response header and served them either unpacked or re-packed when the `CONTENT_ENCODING` environment variable is set to `true`. 

*PR fix:*
This PR makes sure encoded content passes through the proxy encoded end-to-end without unpacking and repacking the content. I also took the liberty to limit the amount of idle connections to 150 and the idle connection timeout to 10 seconds. 